### PR TITLE
CI: Github actions fix commit status on new PR

### DIFF
--- a/.github/workflows/windows-qe-tpl.yml
+++ b/.github/workflows/windows-qe-tpl.yml
@@ -56,9 +56,9 @@ jobs:
       run: |
         # Get origin commit sha for testing
         commit_sha=$(cat gh_context.json | jq -r '.event.after')
-        if [[ -z "${commit_sha}" ]]; then
+        if [[ -z "${commit_sha}" ]] || [[ "${commit_sha}" == null ]]; then
           # on first PR creation .event.after is empty, then .sha is used as commit instead
-          commit_sha=$(cat gh_context.json | jq -r '.sha')
+          commit_sha=$(cat gh_context.json | jq -r '.event.pull_request.head.sha')
         fi
         echo "commit_sha=${commit_sha}" >> "$GITHUB_ENV"
         


### PR DESCRIPTION
On windows tester actions we are adding the status to the latest commit on a PR; to get the commit value we inspect the gh context but the condition to get the value on a new PR (.event.after is null) is not catch by the expression and so the .sha value is not picked; as so the status is not correctly added to the commit. This fix extends the condition to check for null values; and if that is the case pick the right commit value


**Fixes:** Issue #N

**Relates to:** Issue #N, PR #N, ...

## Solution/Idea

Describe in plain English what you solved and how. For instance, _Added `start` command to CRC so the user can create a VM and set-up a single-node OpenShift cluster on it with one command. It requires blablabla..._

## Proposed changes

List main as well as consequential changes you introduced or had to introduce.

1. Add `start` command.
2. Add `setup` as prerequisite to `start`.
3. ...

## Testing

What is the _bottom-line_ functionality that needs testing? Describe in pseudo-code or in English. Use verifiable statements that tie your changes to existing functionality.

1. `start` succeeds first time after `setup` succeeded
2. stdout contains ... if `start` succeeded
3. stderr contains ... after `start` failed
4. `status` returns ... if `start` succeeded
5. `status` returns ... if `start` failed
6. `start` fails after `start` succeeded or after `status` says CRC is `Running`
7. ...
