### PR TITLE
[qe] increase default timeout for integration tests suite

### DIFF
--- a/images/build-integration/lib/windows/run.ps1
+++ b/images/build-integration/lib/windows/run.ps1
@@ -4,7 +4,9 @@ param(
     [Parameter(HelpMessage='Name of the folder on the target host under $HOME where all the content will be copied')]
     $targetFolder="crc-integration",
     [Parameter(HelpMessage='Name for the junit file with the tests results')]
-    $junitFilename="integration-junit.xml"
+    $junitFilename="integration-junit.xml",
+    [Parameter(HelpMessage='Test suite fails if it does not complete within the specified timeout. Default 90m')]
+    $suiteTimeout="90m"
 )
 
 # Prepare run e2e
@@ -22,7 +24,7 @@ if ($bundleLocation) {
 }
 # We need to copy the pull-secret to the target folder
 $env:PULL_SECRET_PATH="$env:HOME\$targetFolder\pull-secret"
-integration.test.exe > integration.results
+integration.test.exe --ginkgo.timeout $suiteTimeout > integration.results
 
 # Copy results
 cd ..


### PR DESCRIPTION
Tests are having false positives due to overall ginkgo timeout default value, this commit will include a mechanism to customize the timeout value when running the tests through the container and also increses the default value to 90 minutes


**Fixes:** Issue #N

**Relates to:** Issue #N, PR #N, ...

## Solution/Idea

Describe in plain English what you solved and how. For instance, _Added `start` command to CRC so the user can create a VM and set-up a single-node OpenShift cluster on it with one command. It requires blablabla..._

## Proposed changes

List main as well as consequential changes you introduced or had to introduce.

1. Add `start` command.
2. Add `setup` as prerequisite to `start`.
3. ...

## Testing

What is the _bottom-line_ functionality that needs testing? Describe in pseudo-code or in English. Use verifiable statements that tie your changes to existing functionality.

1. `start` succeeds first time after `setup` succeeded
2. stdout contains ... if `start` succeeded
3. stderr contains ... after `start` failed
4. `status` returns ... if `start` succeeded
5. `status` returns ... if `start` failed
6. `start` fails after `start` succeeded or after `status` says CRC is `Running`
7. ...
